### PR TITLE
Add ability to show/hide hidden games in all modes

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -94,12 +94,12 @@ std::vector<FileData*> FileData::getChildren(bool filter) const
 	if (filter)
 	{
 		//filter out unwanted items from mChildren
-		bool filterHidden = (Settings::getInstance()->getString("UIMode") != "Full");
+		bool filterHidden = (Settings::getInstance()->getString("UIMode") != "Full") || !(Settings::getInstance()->getBool("ShowHidden"));
 		bool filterFav = (Settings::getInstance()->getBool("FavoritesOnly"));
 		bool filterKid = (Settings::getInstance()->getString("UIMode") == "Kid");
-		
+
 		LOG(LogDebug) << "   filtering (" << filterHidden << filterFav << filterKid << ").";
-		
+
 		// then filter out all we do not want.
 		if (filterHidden) {
 			fileList = filterFileData(fileList, "hidden", "false");
@@ -125,22 +125,22 @@ std::vector<FileData*> FileData::getFilesRecursive(unsigned int typeMask, bool f
 	// first populate with all we can find
 	std::vector<FileData*> allfiles = getChildren(filter);
 	std::vector<FileData*> fileList;
-	
+
 	//LOG(LogDebug) << "FileData::getFilesRecursive(): allfiles contains " << allfiles.size() << " items";
 
-	for(auto it = allfiles.begin(); it != allfiles.end(); it++) 
+	for(auto it = allfiles.begin(); it != allfiles.end(); it++)
 	{
 		if((*it)->getType() & typeMask) {
 			fileList.push_back(*it);
 		}
-		
+
 		if((*it)->getChildren(filter).size() > 1) {
 			//LOG(LogDebug) << "FileData::getFilesRecursive(): Recursing!";
 			std::vector<FileData*> subchildren = (*it)->getFilesRecursive(typeMask, filter);
 			fileList.insert(fileList.end(), subchildren.cbegin(), subchildren.cend());
 		}
 	}
-		
+
 
 	LOG(LogDebug) << "FileData::getFilesRecursive():returning " << fileList.size() << " games";
 	return fileList;
@@ -212,12 +212,12 @@ void FileData::sort(const SortType& type)
 FileData* FileData::getRandom() const
 {
 	LOG(LogDebug) << "FileData::getRandom()";
-	
+
 	//Get list of files
 	std::vector<FileData*> list = getFilesRecursive(GAME,true); // always filter
 	const unsigned long n = list.size();
 	LOG(LogDebug) << "   found games: " << n;
-	
+
 	//Select random system
 	//const unsigned long divisor = (RAND_MAX + 1) / n;
 	const unsigned long divisor = (RAND_MAX) / n; // the above is correct, but gives compiler warning.
@@ -225,7 +225,7 @@ FileData* FileData::getRandom() const
 	do {
 		k = std::rand() / divisor;
 	} while (k >= n); // pick the first within range
-	
+
 	LOG(LogDebug) << "   Picked game: " << list.at(k)->getName();
-	return list.at(k);	
+	return list.at(k);
 }

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -96,17 +96,36 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	});
 
 	// Toggle: Show hidden
-	auto show_hidden = std::make_shared<SwitchComponent>(mWindow);
-	show_hidden->setState(Settings::getInstance()->getBool("ShowHidden"));
-	mMenu.addWithLabel("SHOW HIDDEN", show_hidden);
-	addSaveFunc([show_hidden, this] {
-		// First save to settings, in order for filtering to work
-		if (show_hidden->getState() != Settings::getInstance()->getBool("ShowHidden"))
-		{
-			Settings::getInstance()->setBool("ShowHidden", show_hidden->getState());
-			mHiddenStateChanged = true;
-		}
-	});
+	if(Settings::getInstance()->getString("UIMode") == "Full")
+	{
+		auto show_hidden = std::make_shared<SwitchComponent>(mWindow);
+		show_hidden->setState(Settings::getInstance()->getBool("ShowHidden"));
+		mMenu.addWithLabel("SHOW HIDDEN", show_hidden);
+		addSaveFunc([show_hidden, this] {
+			// First save to settings, in order for filtering to work
+			if(show_hidden->getState() != Settings::getInstance()->getBool("ShowHidden"))
+			{
+				Settings::getInstance()->setBool("ShowHidden", show_hidden->getState());
+				mHiddenStateChanged = true;
+			}
+			if(!show_hidden->getState())
+			{
+				bool hasNonHidden = false;
+				for(auto it = SystemData::sSystemVector.begin(); it != SystemData::sSystemVector.end(); it++) {
+					if( (*it)->getGameCount(true) > 0 ) {
+						hasNonHidden = true;
+						break;
+					}
+				}
+				if(!hasNonHidden)
+				{
+					LOG(LogDebug) << "Nothing to show in selected show hidden mode, resetting";
+					show_hidden->setState(true);
+					Settings::getInstance()->setBool("ShowHidden", show_hidden->getState());
+				}
+			}
+		});
+	}
 
 	// edit game metadata - only in Full UI mode
 	if(Settings::getInstance()->getString("UIMode") == "Full")

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -22,24 +22,25 @@ private:
 	void openMetaDataEd();
 	void jumpToLetter();
 	void SurpriseMe();
-	
-	
+
+
 	MenuComponent mMenu;
 
 	std::vector< std::function<void()> > mSaveFuncs;
 
 	typedef OptionListComponent<char> LetterList;
 	std::shared_ptr<LetterList> mJumpToLetterList;
-	
+
 	typedef OptionListComponent<const FileData::SortType*> SortList;
 	std::shared_ptr<SortList> mListSort;
 
 	std::shared_ptr<SwitchComponent> mFavoriteOption;
 	bool mFavoriteStateChanged;
+	bool mHiddenStateChanged;
 
 	typedef OptionListComponent<std::string> SurpriseEnums;
 	std::shared_ptr<SurpriseEnums> mSurpriseModes;
-	
+
 	SystemData* mSystem;
 	IGameListView* getGamelist();
 };


### PR DESCRIPTION
In Kids/Kiosk mode hidden games are not shown. However, I also want to be able to use Full mode, but still hide those hidden games. This change adds a menu option next to the "favorites only" toggle, and then filters the game list accordingly.

<img src="http://cloud.mattnohr.com/0f371N0J402q/Screen%20Shot%202016-09-21%20at%208.19.59%20PM.png" width="400px" />

_Note:_ I also removed some trailing whitespace in the files I touched in an attempt to clean up the code a bit.
